### PR TITLE
[chore] moving from bitbucket to GH

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,30 @@
 
 ## Installation
 
-1. install `https://bitbucket.org/shiftsmart/surveyjs-react-native`
+1. install `https://github.com/shiftsmartinc/surveyjs-react-native`
 
 2. install peerDependencies:
-  * `mobx`
-  * `mobx-react`
-  * `moment`
-  * `react`
-  * `react-native`
-  * `react-native-image-picker`
-  * `react-native-keyboard-aware-scroll-view`
-  * `react-native-modal-datetime-picker`
-  * `react-native-webview`
-  * `@react-native-community/datetimepicker`
+
+- `mobx`
+- `mobx-react`
+- `moment`
+- `react`
+- `react-native`
+- `react-native-image-picker`
+- `react-native-keyboard-aware-scroll-view`
+- `react-native-modal-datetime-picker`
+- `react-native-webview`
+- `@react-native-community/datetimepicker`
 
 3. Add the required permissions in AndroidManifest.xml:
+
 ```xml
 <uses-permission android:name="android.permission.CAMERA" />
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
 4. Add the required permissions in Info.plist:
+
 ```xml
 <key>NSPhotoLibraryUsageDescription</key>
 <string></string>
@@ -32,7 +35,7 @@
 <string></string>
 ```
 
-# Example
+## Example
 
 1. `cd example`
 2. install dependencies

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "react-native-keyboard-aware-scroll-view": "github:APSL/react-native-keyboard-aware-scroll-view#v0.9.2",
     "react-native-modal-datetime-picker": "^8.9.3",
     "react-native-webview": "^10.3.3",
-    "surveyjs-react-native": "git+https://github.com/shiftsmartinc/surveyjs-react-native"
+    "surveyjs-react-native": "github:shiftsmartinc/surveyjs-react-native"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "react-native-keyboard-aware-scroll-view": "github:APSL/react-native-keyboard-aware-scroll-view#v0.9.2",
     "react-native-modal-datetime-picker": "^8.9.3",
     "react-native-webview": "^10.3.3",
-    "surveyjs-react-native": "git+https://bitbucket.org/shiftsmart/surveyjs-react-native.git"
+    "surveyjs-react-native": "git+https://github.com/shiftsmartinc/surveyjs-react-native"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
# Overview 

We've essentially deprecated Bitbucket in favor of Github but there are still a few small pieces that need to be moved off. This `surveyjs-react-native` repo/package is one such instance. 

- [Installing specific version via npm](https://stackoverflow.com/questions/14187956/npm-install-from-git-in-a-specific-version)
- https://github.com/shiftsmartinc/nativeapps/pull/501
- This bitbucket references [are here](https://github.com/search?q=org%3Ashiftsmartinc+surveyjs-react-native&type=code)

## Testing

Not too much to test on this side, we're just updating the old references.

- Post deploy we should spin that repo in bitbucket down