### PR TITLE
chore: web view opacity hack

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Summary
+
+- https://shiftsmart.atlassian.net/browse/SSM-XXXX
+
+Summarize the changes we're making, if the PR is focused, summary should be as well.
+
+## Testing
+
+- [ ] tbd...
+
+<!--
+
+## Checklist
+
+- PR Title Clearly Summarizes Changes
+- Summary section describes Who/What/Why
+- Testing block enumerates how to test the feature
+- PR has appropriate labels added
+- Linting & Automated Test Pipelines are Passing
+- New Code has been covered by Test Suite
+
+-->

--- a/dist/QuestionHtml.js
+++ b/dist/QuestionHtml.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Linking } from 'react-native';
+import { StyleSheet, Linking, Platform } from 'react-native';
 import WebView from 'react-native-webview';
 const styles = StyleSheet.create({
     container: {
@@ -54,7 +54,11 @@ class MyWebView extends React.Component {
         const height = this.props.autoHeight
             ? this.state.webViewHeight
             : this.props.defaultHeight;
-        return (<WebView injectedJavaScript={injectedScript} scrollEnabled={this.props.scrollEnabled || false} onNavigationStateChange={this._onNavigationStateChange} onMessage={this._onMessage} javaScriptEnabled={true} automaticallyAdjustContentInsets={true} {...this.props} style={[styles.container, this.props.style, { height }]} androidHardwareAccelerationDisabled={!!'https://github.com/react-native-webview/react-native-webview/issues/811'}/>);
+        return (<WebView {...this.props} automaticallyAdjustContentInsets={true} injectedJavaScript={injectedScript} javaScriptEnabled={true} onMessage={this._onMessage} onNavigationStateChange={this._onNavigationStateChange} scrollEnabled={this.props.scrollEnabled || false} style={[
+                styles.container,
+                this.props.style,
+                { height, opacity: Platform.OS === 'android' ? 0.99 : 1 },
+            ]}/>);
     }
 }
 export default class QuestionHtml extends React.Component {

--- a/src/QuestionHtml.tsx
+++ b/src/QuestionHtml.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Linking } from 'react-native';
+import { StyleSheet, Linking, Platform } from 'react-native';
 import WebView from 'react-native-webview';
 
 const styles = StyleSheet.create({
@@ -92,17 +92,21 @@ class MyWebView extends React.Component<any, any> {
 
     return (
       <WebView
-        injectedJavaScript={injectedScript}
-        scrollEnabled={this.props.scrollEnabled || false}
-        onNavigationStateChange={this._onNavigationStateChange}
-        onMessage={this._onMessage}
-        javaScriptEnabled={true}
-        automaticallyAdjustContentInsets={true}
         {...this.props}
-        style={[styles.container, this.props.style, { height }]}
-        androidHardwareAccelerationDisabled={
-          !!'https://github.com/react-native-webview/react-native-webview/issues/811'
-        }
+        // androidHardwareAccelerationDisabled={
+        //   !!'https://github.com/react-native-webview/react-native-webview/issues/811'
+        // }
+        automaticallyAdjustContentInsets={true}
+        injectedJavaScript={injectedScript}
+        javaScriptEnabled={true}
+        onMessage={this._onMessage}
+        onNavigationStateChange={this._onNavigationStateChange}
+        scrollEnabled={this.props.scrollEnabled || false}
+        style={[
+          styles.container,
+          this.props.style,
+          { height, opacity: Platform.OS === 'android' ? 0.99 : 1 },
+        ]}
       />
     );
   }

--- a/src/QuestionHtml.tsx
+++ b/src/QuestionHtml.tsx
@@ -93,9 +93,6 @@ class MyWebView extends React.Component<any, any> {
     return (
       <WebView
         {...this.props}
-        // androidHardwareAccelerationDisabled={
-        //   !!'https://github.com/react-native-webview/react-native-webview/issues/811'
-        // }
         automaticallyAdjustContentInsets={true}
         injectedJavaScript={injectedScript}
         javaScriptEnabled={true}


### PR DESCRIPTION
# Overview

This PR applies a hack / work around also applied here https://github.com/shiftsmartinc/nativeapps/pull/1172. From there we run a `yarn build` and committed things. We'll need to update native apps with the hash post-merge of this PR. 

## Testing

- [ ] A bit hard to test, but have a look over the diff
- [ ] Same changes as in the [PR here](https://github.com/shiftsmartinc/nativeapps/pull/1172) applying a workaround