### PR TITLE
chore: [AI-291] allow html text in question description and name

### DIFF
--- a/dist/HtmlText.d.ts
+++ b/dist/HtmlText.d.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+interface HtmlTextComponentProps {
+    children: string;
+    style?: any;
+    textStyle?: any;
+}
+export default class HtmlText extends React.Component<HtmlTextComponentProps> {
+    render(): JSX.Element;
+}
+export {};

--- a/dist/HtmlText.js
+++ b/dist/HtmlText.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { StyleSheet, Text, View, Linking, Platform } from 'react-native';
+import WebView from 'react-native-webview';
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    webView: {
+        backgroundColor: 'transparent',
+    },
+});
+const createInjectedStyles = (textStyle) => {
+    const color = textStyle?.color || '#000';
+    const fontSize = textStyle?.fontSize || 14;
+    const fontWeight = textStyle?.fontWeight || 'normal';
+    const fontFamily = '-apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu';
+    return `
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: transparent;
+        color: ${color};
+        font-size: ${fontSize}px;
+        font-weight: ${fontWeight};
+        font-family: ${fontFamily};
+      }
+    </style>
+  `;
+};
+const injectedMeta = `<meta name="viewport" content="width=device-width, initial-scale=1" />`;
+const injectedScript = `window.ReactNativeWebView.postMessage(document.body.scrollHeight)`;
+const containsHtml = (text) => {
+    if (!text)
+        return false;
+    const htmlRegex = /<[^>]+>/;
+    return htmlRegex.test(text);
+};
+class HtmlWebView extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            webViewHeight: props.defaultHeight || 1,
+        };
+        this._onMessage = this._onMessage.bind(this);
+        this._onNavigationStateChange = this._onNavigationStateChange.bind(this);
+    }
+    _onMessage(e) {
+        this.setState({
+            webViewHeight: parseInt(e.nativeEvent.data, 10) || this.props.defaultHeight || 1,
+        });
+    }
+    _onNavigationStateChange(e) {
+        if (this.props.onNavigationStateChange) {
+            return this.props.onNavigationStateChange(e);
+        }
+        if (e.url.indexOf('http') > -1 && e.url.indexOf('data:text/html') === -1) {
+            Linking.openURL(e.url);
+            return false;
+        }
+        return false;
+    }
+    render() {
+        const { html, style, textStyle, defaultHeight = 1 } = this.props;
+        const { webViewHeight } = this.state;
+        const injectedStyles = createInjectedStyles(textStyle);
+        return (<WebView source={{
+                html: `${injectedMeta}${injectedStyles}${html}`,
+            }} style={[
+                styles.webView,
+                style,
+                { height: webViewHeight, opacity: Platform.OS === 'android' ? 0.99 : 1 },
+            ]} injectedJavaScript={injectedScript} javaScriptEnabled={true} onMessage={this._onMessage} onNavigationStateChange={this._onNavigationStateChange} scrollEnabled={false} automaticallyAdjustContentInsets={true} showsVerticalScrollIndicator={false} showsHorizontalScrollIndicator={false}/>);
+    }
+}
+export default class HtmlText extends React.Component {
+    render() {
+        const { children, style, textStyle } = this.props;
+        if (!children) {
+            return null;
+        }
+        if (!containsHtml(children)) {
+            return (<View style={style}>
+          <Text style={textStyle}>{children}</Text>
+        </View>);
+        }
+        return (<View style={style}>
+        <HtmlWebView html={children} textStyle={textStyle} defaultHeight={1}/>
+      </View>);
+    }
+}

--- a/dist/QuestionWrapper.js
+++ b/dist/QuestionWrapper.js
@@ -12,6 +12,7 @@ import QuestionPanelDynamic from './QuestionPanelDynamic';
 import QuestionHtml from './QuestionHtml';
 import QuestionFile from './QuestionFile';
 import QuestionTextWrapper from './QuestionTextWrapper';
+import HtmlText from './HtmlText';
 const styles = StyleSheet.create({
     container: {
         marginTop: 10,
@@ -129,14 +130,14 @@ class QuestionWrapper extends React.Component {
         }
         return (<View key={json.name} style={styles.container}>
         {showTitle && question.json.type !== 'html' && (<View style={[styles.title, isPreview && styles.previewTitle]}>
-            <Text style={[styles.titleText, isPreview && styles.previewTitleText]}>
-              {number ? `${number}.` : ''} {renderedTitle || name}
-            </Text>
+            <HtmlText textStyle={[styles.titleText, isPreview && styles.previewTitleText]}>
+              {`${number ? `${number}. ` : ''}${renderedTitle || name}`}
+            </HtmlText>
           </View>)}
         {renderedDescription && (<View style={styles.description}>
-            <Text style={[styles.descriptionText, isPreview && styles.previewDescriptionText]}>
+            <HtmlText textStyle={[styles.descriptionText, isPreview && styles.previewDescriptionText]}>
               {renderedDescription}
-            </Text>
+            </HtmlText>
           </View>)}
         {question.error && (<View style={styles.error}>
             <Text style={styles.errorText}>{question.error}</Text>

--- a/src/HtmlText.tsx
+++ b/src/HtmlText.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { StyleSheet, Text, View, Linking, Platform } from 'react-native';
+import WebView from 'react-native-webview';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  webView: {
+    backgroundColor: 'transparent',
+  },
+});
+
+const createInjectedStyles = (textStyle?: any): string => {
+  const color = textStyle?.color || '#000';
+  const fontSize = textStyle?.fontSize || 14;
+  const fontWeight = textStyle?.fontWeight || 'normal';
+  const fontFamily = '-apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu';
+  
+  return `
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: transparent;
+        color: ${color};
+        font-size: ${fontSize}px;
+        font-weight: ${fontWeight};
+        font-family: ${fontFamily};
+      }
+    </style>
+  `;
+};
+
+const injectedMeta = `<meta name="viewport" content="width=device-width, initial-scale=1" />`;
+
+const injectedScript = `window.ReactNativeWebView.postMessage(document.body.scrollHeight)`;
+
+// Simple check to see if string contains HTML tags
+const containsHtml = (text: string): boolean => {
+  if (!text) return false;
+  const htmlRegex = /<[^>]+>/;
+  return htmlRegex.test(text);
+};
+
+interface HtmlTextProps {
+  html: string;
+  style?: any;
+  textStyle?: any;
+  onNavigationStateChange?: (e: any) => boolean;
+  defaultHeight?: number;
+}
+
+class HtmlWebView extends React.Component<HtmlTextProps, { webViewHeight: number }> {
+  constructor(props: HtmlTextProps) {
+    super(props);
+    this.state = {
+      webViewHeight: props.defaultHeight || 1,
+    };
+    this._onMessage = this._onMessage.bind(this);
+    this._onNavigationStateChange = this._onNavigationStateChange.bind(this);
+  }
+
+  _onMessage(e: any) {
+    this.setState({
+      webViewHeight: parseInt(e.nativeEvent.data, 10) || this.props.defaultHeight || 1,
+    });
+  }
+
+  _onNavigationStateChange(e: any) {
+    if (this.props.onNavigationStateChange) {
+      return this.props.onNavigationStateChange(e);
+    }
+    // Default behavior: open external links
+    if (e.url.indexOf('http') > -1 && e.url.indexOf('data:text/html') === -1) {
+      Linking.openURL(e.url);
+      return false;
+    }
+    return false;
+  }
+
+  render() {
+    const { html, style, textStyle, defaultHeight = 1 } = this.props;
+    const { webViewHeight } = this.state;
+    const injectedStyles = createInjectedStyles(textStyle);
+
+    return (
+      <WebView
+        source={{
+          html: `${injectedMeta}${injectedStyles}${html}`,
+        }}
+        style={[
+          styles.webView,
+          style,
+          { height: webViewHeight, opacity: Platform.OS === 'android' ? 0.99 : 1 },
+        ]}
+        injectedJavaScript={injectedScript}
+        javaScriptEnabled={true}
+        onMessage={this._onMessage}
+        onNavigationStateChange={this._onNavigationStateChange}
+        scrollEnabled={false}
+        automaticallyAdjustContentInsets={true}
+        showsVerticalScrollIndicator={false}
+        showsHorizontalScrollIndicator={false}
+      />
+    );
+  }
+}
+
+interface HtmlTextComponentProps {
+  children: string;
+  style?: any;
+  textStyle?: any;
+}
+
+export default class HtmlText extends React.Component<HtmlTextComponentProps> {
+  render() {
+    const { children, style, textStyle } = this.props;
+
+    if (!children) {
+      return null;
+    }
+
+    // If content doesn't contain HTML, use regular Text component for better performance
+    if (!containsHtml(children)) {
+      return (
+        <View style={style}>
+          <Text style={textStyle}>{children}</Text>
+        </View>
+      );
+    }
+
+    // If content contains HTML, use WebView
+    return (
+      <View style={style}>
+        <HtmlWebView
+          html={children}
+          textStyle={textStyle}
+          defaultHeight={1}
+        />
+      </View>
+    );
+  }
+}
+

--- a/src/QuestionWrapper.tsx
+++ b/src/QuestionWrapper.tsx
@@ -12,6 +12,7 @@ import QuestionPanelDynamic from './QuestionPanelDynamic';
 import QuestionHtml from './QuestionHtml';
 import QuestionFile from './QuestionFile';
 import QuestionTextWrapper from './QuestionTextWrapper';
+import HtmlText from './HtmlText';
 
 const styles = StyleSheet.create({
   container: {
@@ -207,18 +208,20 @@ class QuestionWrapper extends React.Component<QuestionWrapperProps> {
       <View key={json.name} style={styles.container}>
         {showTitle && question.json.type !== 'html' && (
           <View style={[styles.title, isPreview && styles.previewTitle]}>
-            <Text
-              style={[styles.titleText, isPreview && styles.previewTitleText]}
+            <HtmlText
+              textStyle={[styles.titleText, isPreview && styles.previewTitleText]}
             >
-              {number ? `${number}.` : ''} {renderedTitle || name}
-            </Text>
+              {`${number ? `${number}. ` : ''}${renderedTitle || name}`}
+            </HtmlText>
           </View>
         )}
         {renderedDescription && (
           <View style={styles.description}>
-            <Text style={[styles.descriptionText, isPreview && styles.previewDescriptionText]}>
+            <HtmlText
+              textStyle={[styles.descriptionText, isPreview && styles.previewDescriptionText]}
+            >
               {renderedDescription}
-            </Text>
+            </HtmlText>
           </View>
         )}
         {question.error && (


### PR DESCRIPTION
# Summary

- https://shiftsmart.atlassian.net/browse/AI-291
- Allows html markup to be rendered for question names and descriptions

## Testing

- [ ] In the `node_modules` of your `nativeapps`, replace the `surveyjs-react-native` `dist` folder with the dist folder in this branch. 
- [ ] Replace the question text of an element in a `surveydefinition` with html markup.
- [ ] Accept a `survey` with that `surveydefintion` and start the survey.
- [ ] Verify that the markup is properly rendered. 

Both of these are wrapped in <p> tags:
[
<img width="502" height="909" alt="Screenshot 2026-01-15 at 3 33 42 PM" src="https://github.com/user-attachments/assets/a768cbdd-751e-4e81-baff-97ae42c3fcba" />
](url)

<!--

## Checklist

- PR Title Clearly Summarizes Changes
- Summary section describes Who/What/Why
- Testing block enumerates how to test the feature
- PR has appropriate labels added
- Linting & Automated Test Pipelines are Passing
- New Code has been covered by Test Suite

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering rich HTML content alongside plain text, with intelligent formatting that automatically adjusts to content type.
  * Improved question title and description rendering with enhanced formatting capabilities.
  * Dynamic height adjustment for content to ensure proper display without truncation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->