### PR TITLE
chore: require commentary for negative choices

### DIFF
--- a/dist/QuestionFile.js
+++ b/dist/QuestionFile.js
@@ -69,7 +69,7 @@ export default class QuestionFile extends React.Component {
             };
             if (allowMultiple && method === 'openPicker') {
                 pickerOptions.multiple = true;
-                pickerOptions.storeDataAsText = false;
+                pickerOptions.includeBase64 = false;
             }
             const response = await imageAction(pickerOptions);
             if (allowMultiple) {

--- a/dist/validator.d.ts
+++ b/dist/validator.d.ts
@@ -4,6 +4,8 @@ export default class QuestionValidator {
     private emailRegex;
     constructor(owner: any);
     validate(): boolean;
+    private isCommentRequiredForCurrentValue;
+    private validateCommentRequired;
     getValidators(): any[];
     validateRequire: (value: any, validator: any) => any;
     validateNumber: (value: any, validator: any) => any;

--- a/dist/validator.js
+++ b/dist/validator.js
@@ -1,6 +1,7 @@
 import { SyntaxError, parse } from './condition/expressions/expressionParser';
 const errorTemplates = {
     requiredError: 'Please answer the question.',
+    commentRequiredError: 'Please provide a comment for this choice.',
     numericError: 'The value should be numeric.',
     numericMin: 'Should be equal or more than {0}',
     numericMax: 'Should be equal or less than {0}',
@@ -79,7 +80,35 @@ export default class QuestionValidator {
             this.owner.setError(error);
             return error;
         });
+        if (!hasError && this.isCommentRequiredForCurrentValue()) {
+            const commentError = this.validateCommentRequired();
+            if (commentError) {
+                this.owner.setError(commentError);
+                return false;
+            }
+        }
         return !hasError;
+    }
+    isCommentRequiredForCurrentValue() {
+        const { json, value } = this.owner;
+        const choicesThatRequireComment = json.choicesThatRequireComment;
+        if (!choicesThatRequireComment?.length ||
+            !json.isRequired ||
+            !json.hasComment) {
+            return false;
+        }
+        const list = Array.isArray(choicesThatRequireComment)
+            ? choicesThatRequireComment
+            : [];
+        const selectedValues = Array.isArray(value) ? value : [value];
+        return selectedValues.some((v) => v != null && list.includes(v));
+    }
+    validateCommentRequired() {
+        if (!this.isValueEmpty(this.owner.comment)) {
+            return null;
+        }
+        const customText = this.owner.json.commentRequiredErrorText;
+        return getErrorStr('commentRequiredError', [], customText || undefined, {});
     }
     getValidators() {
         const originalValidators = this.owner.json.validators || [];

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,6 +2,7 @@ import { SyntaxError, parse } from './condition/expressions/expressionParser';
 
 const errorTemplates = {
   requiredError: 'Please answer the question.',
+  commentRequiredError: 'Please provide a comment for this choice.',
   numericError: 'The value should be numeric.',
   numericMin: 'Should be equal or more than {0}',
   numericMax: 'Should be equal or less than {0}',
@@ -99,7 +100,49 @@ export default class QuestionValidator {
       return error;
     });
 
+    if (!hasError && this.isCommentRequiredForCurrentValue()) {
+      const commentError = this.validateCommentRequired();
+      if (commentError) {
+        this.owner.setError(commentError);
+        return false;
+      }
+    }
+
     return !hasError;
+  }
+
+  /**
+   * Returns true when the question has choicesThatRequireComment populated,
+   * isRequired, hasComment, and the current value (or any selected value) is in choicesThatRequireComment.
+   */
+  private isCommentRequiredForCurrentValue(): boolean {
+    const { json, value } = this.owner;
+    const choicesThatRequireComment = json.choicesThatRequireComment;
+    if (
+      !choicesThatRequireComment?.length ||
+      !json.isRequired ||
+      !json.hasComment
+    ) {
+      return false;
+    }
+    const list = Array.isArray(choicesThatRequireComment)
+      ? choicesThatRequireComment
+      : [];
+    const selectedValues = Array.isArray(value) ? value : [value];
+    return selectedValues.some((v: any) => v != null && list.includes(v));
+  }
+
+  private validateCommentRequired(): string | null {
+    if (!this.isValueEmpty(this.owner.comment)) {
+      return null;
+    }
+    const customText = (this.owner.json as any).commentRequiredErrorText;
+    return getErrorStr(
+      'commentRequiredError',
+      [],
+      customText || undefined,
+      {},
+    );
   }
 
   getValidators() {


### PR DESCRIPTION
# Summary

- https://shiftsmart.atlassian.net/browse/AI-441
- Implements new validation for questions with `choicesThatRequireComment` populated. 
## Testing

- [ ] In your `nativeapps`, replace the `dist` directory of `surveyjs-react-native` with the contents from the dist directory of this branch. 
- [ ] For a survey def in your local db, add the two following questions:
```
 {
                        "type" : "radiogroup",
                        "name" : "27619",
                        "title" : "Did the Leasing Professional encourage you to complete an application or leave a deposit to reserve an apartment?",
                        "choices" : [
                            "Yes",
                            "No",
                            "N/A"
                        ],
                        "points" : [
                            NumberInt(4),
                            NumberInt(0),
                            null
                        ],
                        "isRequired" : true,
                        "choicesThatRequireComment" : [
                            "No",
                            "N/A"
                        ],
                        "hasComment" : true,
                        "description" : "Please provide any comments below."
                    },
                    {
                        "type" : "radiogroup",
                        "name" : "27620",
                        "title" : "Did the Leasing Professional attempt to close more than once?",
                        "choices" : [
                            "Yes",
                            "No",
                            "N/A"
                        ],
                        "points" : [
                            NumberInt(4),
                            NumberInt(0),
                            null
                        ],
                        "isRequired" : true,
                        "hasComment" : true,
                        "description" : "Please provide any comments below."
                    }
```
- [ ] Pick up the survey and go to complete it.
- [ ] Verify that for the first one, you need to provide a comment if the answer you select is "No" or "N/A".
- [ ] Verify that for the second one, that rule doesn't apply. 

<!--

## Checklist

- PR Title Clearly Summarizes Changes
- Summary section describes Who/What/Why
- Testing block enumerates how to test the feature
- PR has appropriate labels added
- Linting & Automated Test Pipelines are Passing
- New Code has been covered by Test Suite

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation requiring comments when selecting specific choices.
  * Custom error messages now display when a required comment is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->